### PR TITLE
实时读取和实时保存

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -177,6 +177,13 @@ export default class PluginSample extends Plugin {
             type: "textinput",
             title: "Readonly text",
             description: "Input description",
+            action: {
+                callback: () => {
+                    // Return data and save it in real time
+                    let value = this.settingUtils.takeAndSave("Input")
+                    console.log(value);
+                }
+            }
         });
         this.settingUtils.addItem({
             key: "InputArea",
@@ -184,6 +191,13 @@ export default class PluginSample extends Plugin {
             type: "textarea",
             title: "Readonly text",
             description: "Input description",
+            action: {
+                callback: () => {
+                    // Read data in real time
+                    let value = this.settingUtils.take("InputArea")
+                    console.log(value);
+                }
+            }
         });
         this.settingUtils.addItem({
             key: "Check",
@@ -191,9 +205,12 @@ export default class PluginSample extends Plugin {
             type: "checkbox",
             title: "Checkbox text",
             description: "Check description",
-            checkbox: {
+            action: {
                 callback: () => {
-                    console.log("Checkbox clicked");
+                    // Return data and save it in real time
+                    let value = !this.settingUtils.get("Check")
+                     this.settingUtils.set("Check", value)
+                    console.log(value);
                 }
             }
         });
@@ -201,11 +218,18 @@ export default class PluginSample extends Plugin {
             key: "Select",
             value: 1,
             type: "select",
-            title: "Readonly text",
+            title: "Select",
             description: "Select description",
             options: {
                 1: "Option 1",
                 2: "Option 2"
+            },
+            action: {
+                callback: () => {
+                    // Read data in real time
+                    let value = this.settingUtils.take("Select")
+                    console.log(value);
+                }
             }
         });
         this.settingUtils.addItem({
@@ -218,6 +242,15 @@ export default class PluginSample extends Plugin {
                 min: 0,
                 max: 100,
                 step: 1,
+            },
+            action:{
+                // The callback is called after the action of Silder changes, 
+                // so it should be the this.settingUtils.get() method.
+                callback: () => {
+                    // Read data in real time
+                    let value = this.settingUtils.get("Slider")
+                    console.log(value);
+                }
             }
         });
         this.settingUtils.addItem({

--- a/src/index.ts
+++ b/src/index.ts
@@ -178,6 +178,7 @@ export default class PluginSample extends Plugin {
             title: "Readonly text",
             description: "Input description",
             action: {
+                // Called when focus is lost and content changes
                 callback: () => {
                     // Return data and save it in real time
                     let value = this.settingUtils.takeAndSave("Input")
@@ -191,6 +192,7 @@ export default class PluginSample extends Plugin {
             type: "textarea",
             title: "Readonly text",
             description: "Input description",
+            // Called when focus is lost and content changes
             action: {
                 callback: () => {
                     // Read data in real time

--- a/src/libs/index.d.ts
+++ b/src/libs/index.d.ts
@@ -12,7 +12,7 @@ interface ISettingItem {
         step: number;
     };
     options?: { [key: string | number]: string };
-    checkbox?: {
+    action?: {
         callback: () => void;
     }
     button?: {

--- a/src/libs/setting-utils.ts
+++ b/src/libs/setting-utils.ts
@@ -212,7 +212,7 @@ export class SettingUtils {
                 let textInputElement: HTMLInputElement = document.createElement('input');
                 textInputElement.className = 'b3-text-field fn__flex-center fn__size200';
                 textInputElement.value = item.value;
-                textInputElement.onkeyup = item.action?.callback ?? (() => { });
+                textInputElement.onchange = item.action?.callback ?? (() => { });
                 itemElement = textInputElement;
 
                 break;
@@ -220,7 +220,7 @@ export class SettingUtils {
                 let textareaElement: HTMLTextAreaElement = document.createElement('textarea');
                 textareaElement.className = "b3-text-field fn__block";
                 textareaElement.value = item.value;
-                textareaElement.onkeyup = item.action?.callback ?? (() => { });
+                textareaElement.onchange = item.action?.callback ?? (() => { });
                 itemElement = textareaElement;
                 break;
             case 'number':

--- a/src/libs/setting-utils.ts
+++ b/src/libs/setting-utils.ts
@@ -80,6 +80,20 @@ export class SettingUtils {
             this.updateElementFromValue(key);
         }
     }
+    /**
+     * Set and save setting item value
+     * If you want to set and save immediately you can use this method
+     * @param key key name
+     * @param value value
+     */
+    async setAndSave(key: string, value: any) {
+        let item = this.settings.get(key);
+        if (item) {
+            item.value = value;
+            this.updateElementFromValue(key);
+            await this.save()
+        }
+    }
 
     /**
      * Disable setting item


### PR DESCRIPTION
主要是应用于设置窗口的几个选项如果要相互传递数据（场景之一：对于不太熟悉ts的插件开发者来说，似乎很容易把经典设置窗口当做插件的主窗口），那么在保存之后才会生效使得选项的数据生效，对于插件使用者来说会麻烦。然而getelement方法似乎比较偏向在class内部中使用。于是围绕实时读取数据和保存在this.settings中的数据设了新的方法take()、takeAndSave()等。并修改了方法使用的描述。